### PR TITLE
Add GEO/AEO Tracker to SEO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 
 ## SEO
 * [Serposcope](https://serposcope.serphacker.com/) - Serposcope is a free and open-source rank tracker to monitor websites ranking in Google and improve your SEO performances. ([Source Code](https://github.com/serphacker/serposcope)) `MIT` `Java`
+* [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) - Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, free. ([Source Code](https://github.com/danishashko/geo-aeo-tracker), [Demo](https://llm-tracker-three.vercel.app/)) `MIT` `TypeScript`
 
 ## Privacy focused analytics
 


### PR DESCRIPTION
Open-source AI visibility analytics dashboard. Tracks brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. MIT license, self-hosted and free.