### PR TITLE
Add GEOScore - AI search visibility scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [Snowplow](http://snowplowanalytics.com/) - Analytics tool for web apps with a lot of data. Have every single event, from your websites, mobile apps, desktop applications and server-side systems, stored in your own data warehouse and available to action in real-time. ([Source Code](https://github.com/snowplow/)) `Apache-2.0` `Scala` `real-time`
 
 ## SEO
+* [GEOScore](https://geoscoreai.com/) - AI search visibility scanner that checks how websites perform in AI search engines like ChatGPT, Perplexity, and Gemini. Free scan with 11 technical checks. `©` `SaaS`
 * [Serposcope](https://serposcope.serphacker.com/) - Serposcope is a free and open-source rank tracker to monitor websites ranking in Google and improve your SEO performances. ([Source Code](https://github.com/serphacker/serposcope)) `MIT` `Java`
 
 ## Privacy focused analytics


### PR DESCRIPTION
## What is GEOScore?

[GEOScore](https://geoscoreai.com) is an AI search visibility scanner that checks how websites perform in AI search engines like ChatGPT, Perplexity, and Gemini. It provides a free scan with 11 technical checks to help website owners understand and improve their visibility in AI-powered search.

## Why add it?

As AI search engines become increasingly important for website traffic, tools that analyze AI search visibility are a natural addition to the SEO section. GEOScore fills a gap in the current list by covering AI search optimization — a growing area that complements traditional SEO tools.

## Changes

Added GEOScore to the SEO section, following the existing format with description and tags.