### PR TITLE
Add GEOScore AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [Snowplow](http://snowplowanalytics.com/) - Analytics tool for web apps with a lot of data. Have every single event, from your websites, mobile apps, desktop applications and server-side systems, stored in your own data warehouse and available to action in real-time. ([Source Code](https://github.com/snowplow/)) `Apache-2.0` `Scala` `real-time`
 
 ## SEO
+* [GEOScore AI](https://geoscoreai.com/) - AI search visibility scanner that checks how your website performs in AI search engines (ChatGPT, Perplexity, Google AI Overviews, Gemini). Runs 11 technical checks. `©` `SaaS`
 * [Serposcope](https://serposcope.serphacker.com/) - Serposcope is a free and open-source rank tracker to monitor websites ranking in Google and improve your SEO performances. ([Source Code](https://github.com/serphacker/serposcope)) `MIT` `Java`
 
 ## Privacy focused analytics


### PR DESCRIPTION
## What is GEOScore AI?
GEOScore AI is a free tool that measures and improves website visibility in AI search engines (ChatGPT, Claude, Gemini). It scans 11 GEO signals and provides actionable optimization recommendations.

- Website: https://geoscoreai.com
- Free tier available
- Categories: AI, SEO, Analytics