### PR TITLE
Add StackData: free SaaS pricing comparison tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [Datafusion](https://datafusion.apache.org) - Arrow centric - SQL and in memory analytics for general usage
 * [Superset-Datafusion](https://github.com/frett27/superset-datafusion) - Superset integration for Datafusion
 * [FullSession](https://www.fullsession.io/) – Session replay and user behavior analytics for websites
+* [StackData](https://greg-rg-git.github.io/stackdata-store/tools/compare/) - Free SaaS pricing comparison tool with data on 800+ tools across 15 categories; structured CSV datasets available for bulk analysis. `©` `SaaS`
 
-  
+
 
 ## Real-time
 


### PR DESCRIPTION
## What this adds

[StackData](https://greg-rg-git.github.io/stackdata-store/tools/compare/) — a free interactive SaaS pricing comparison tool covering 800+ tools across 15 categories (SaaS, analytics, accounting, e-commerce, and more), with structured CSV datasets available for bulk analysis.

Added to **General analytics** as a pricing data and market intelligence resource.

## Why it fits

awesome-analytics covers tools that help teams analyze data. StackData's free comparison tool lets analysts and founders analyze SaaS pricing data across the market — a form of competitive market analytics that doesn't currently have representation in the list.

The tool itself is free: https://greg-rg-git.github.io/stackdata-store/tools/compare/