### PR TITLE
Add Beam — privacy-first web analytics on Cloudflare Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [GoatCounter](https://www.goatcounter.com/) - GoatCounter is an open source web analytics platform available as a hosted service (free for non-commercial use) or self-hosted app. ([Source](https://github.com/arp242/goatcounter), [Demo](https://stats.arp242.net/)) `MIT` `SaaS` `Self-Hosted`
 * [Rybbit Analytics](https://rybbit.com/) - Rybbit is powerful, lightweight, and super easy to use analytics. Cookieless and GDPR compliant. Hosted on EU infrastructure in Germany. Self-hosting compatible `©` `SaaS` `self-hosted` `EU`
 * [Clickport](https://clickport.io/) - Privacy-first web analytics without cookies. GDPR compliant, EU-hosted, with session tracking, goals, and real-time dashboard. `©` `SaaS` `EU`
+* [Beam](https://beam.keylightdigital.com/) - Privacy-first, cookie-free web analytics built on Cloudflare Workers edge infrastructure. GDPR compliant, custom events, goals, traffic source channels, and real-time dashboard. Open-source tracking script. ([Demo](https://beam.keylightdigital.com/demo), [Source](https://github.com/scobb/beam.js)) `©` `SaaS`
 
 ## Heatmap analytics
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [GoatCounter](https://www.goatcounter.com/) - GoatCounter is an open source web analytics platform available as a hosted service (free for non-commercial use) or self-hosted app. ([Source](https://github.com/arp242/goatcounter), [Demo](https://stats.arp242.net/)) `MIT` `SaaS` `Self-Hosted`
 * [Rybbit Analytics](https://rybbit.com/) - Rybbit is powerful, lightweight, and super easy to use analytics. Cookieless and GDPR compliant. Hosted on EU infrastructure in Germany. Self-hosting compatible `©` `SaaS` `self-hosted` `EU`
 * [Clickport](https://clickport.io/) - Privacy-first web analytics without cookies. GDPR compliant, EU-hosted, with session tracking, goals, and real-time dashboard. `©` `SaaS` `EU`
-* [Beam](https://beam.keylightdigital.com/) - Privacy-first, cookie-free web analytics built on Cloudflare Workers edge infrastructure. GDPR compliant, custom events, goals, traffic source channels, and real-time dashboard. Open-source tracking script. ([Demo](https://beam.keylightdigital.com/demo), [Source](https://github.com/scobb/beam.js)) `©` `SaaS`
+* [Beam](https://beam-privacy.com/) - Privacy-first, cookie-free web analytics built on Cloudflare Workers edge infrastructure. GDPR compliant, custom events, goals, traffic source channels, and real-time dashboard. Open-source tracking script. ([Demo](https://beam-privacy.com/demo), [Source](https://github.com/scobb/beam.js)) `©` `SaaS`
 
 ## Heatmap analytics
 


### PR DESCRIPTION
## Add Beam Analytics

**What is Beam?**

Beam is a privacy-first, cookie-free web analytics service built on Cloudflare Workers, D1, and KV. No cookies, no personal data stored, GDPR compliant.

**Why it belongs in Privacy focused analytics:**
- No cookies, no personal data stored
- GDPR, CCPA compliant — no consent banner required
- Sub-2KB open-source tracking script: https://github.com/scobb/beam.js
- Supports custom events, goals, traffic source channel analysis
- Free tier available (1 site, 50K pv/mo); Pro plan at $5/month (affordable for indie developers)
- Runs on Cloudflare global edge network

**Live product:** https://beam-privacy.com/
**Live demo:** https://beam-privacy.com/demo
**Open-source tracking script:** https://github.com/scobb/beam.js