### PR TITLE
Add Beam — privacy-first analytics on Cloudflare Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [GoatCounter](https://www.goatcounter.com/) - GoatCounter is an open source web analytics platform available as a hosted service (free for non-commercial use) or self-hosted app. ([Source](https://github.com/arp242/goatcounter), [Demo](https://stats.arp242.net/)) `MIT` `SaaS` `Self-Hosted`
 * [Rybbit Analytics](https://rybbit.com/) - Rybbit is powerful, lightweight, and super easy to use analytics. Cookieless and GDPR compliant. Hosted on EU infrastructure in Germany. Self-hosting compatible `©` `SaaS` `self-hosted` `EU`
 * [Clickport](https://clickport.io/) - Privacy-first web analytics without cookies. GDPR compliant, EU-hosted, with session tracking, goals, and real-time dashboard. `©` `SaaS` `EU`
+* [Beam](https://beam-privacy.com/) - Lightweight, cookie-free web analytics on Cloudflare Workers and D1. No cookies, no fingerprinting, GDPR-compliant by design. Free tier included. ([Source Code](https://github.com/scobb/beam.js)) `©` `SaaS`
 
 ## Heatmap analytics
 


### PR DESCRIPTION
Beam is a lightweight, cookie-free web analytics platform built on Cloudflare Workers + D1. No cookies, no fingerprinting, GDPR-compliant by design.

- Site: https://beam-privacy.com
- Tracking script (open-source): https://github.com/scobb/beam.js
- Free tier: 1 site, 50K pageviews/month
- Pro: $5/month, unlimited sites