### PR TITLE
Add toprank to SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 
 ## SEO
 * [Serposcope](https://serposcope.serphacker.com/) - Serposcope is a free and open-source rank tracker to monitor websites ranking in Google and improve your SEO performances. ([Source Code](https://github.com/serphacker/serposcope)) `MIT` `Java`
+* [toprank](https://github.com/nowork-studio/toprank) - Open-source Claude Code plugin that pulls real Google Search Console and PageSpeed Insights data, audits traffic, rewrites meta tags, generates JSON-LD schema markup, and ships fixes directly to WordPress, Strapi, Contentful, or Ghost. ([Source Code](https://github.com/nowork-studio/toprank)) `MIT` `Python`
 
 ## Privacy focused analytics
 


### PR DESCRIPTION
Adds **toprank** under SEO (second entry, alongside Serposcope).

toprank is an open-source (MIT) Claude Code plugin that pulls real Google Search Console and PageSpeed Insights data, audits traffic, rewrites meta tags, generates JSON-LD schema markup, and ships fixes directly to WordPress, Strapi, Contentful, or Ghost. 9 skills total covering SEO audit, keyword research, content writing, meta tag optimization, schema markup, CMS connectors, Google Ads campaign management, and cross-model review.

## Traction
- **107 GitHub stars, 14 forks**
- MIT licensed, actively maintained
- CHANGELOG, unit tests, and LLM-judge eval tests

- Source: https://github.com/nowork-studio/toprank