### PR TITLE
Add mbuzz to Attribution tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The tools listed here are not necessarily mobile analytics tools only. However t
 * [Adjust](http://adjust.com/) - open-source SDK with sophisticated analysis and campaign tracking. `©` `SaaS`
 * [Clickmeter](https://clickmeter.com) - analytics tool that helps you track marketing campaigns. `©` `SaaS`
 * [HasOffers Mobile app tracking](http://www.mobileapptracking.com/) - attribution analytics platform. `©` `SaaS`
+* [mbuzz](https://mbuzz.co/) - server-side multi-touch attribution platform with open-source SDKs for Ruby, Node, Python, and PHP, plus a SQL-like attribution DSL. `©` `SaaS`
 
 ## Social media analytics
 


### PR DESCRIPTION
Adds mbuzz to the Attribution tracking section.

  - Homepage: https://mbuzz.co
  - SDKs: https://github.com/mbuzzco (Ruby, Node, Python, PHP, Shopify, sGTM)
  - Category: Server-side multi-touch attribution

Disclosure: I work on mbuzz. Entry follows the existing section style (`©` `SaaS` tags). Placed after HasOffers, matching the section's current ordering.