### PR TITLE
Add stratif.io to General analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [UXWizz](https://www.uxwizz.com/) - Self-hosted web analytics with heatmaps, session-recordings, A/B tests and more. `©` `Self-Hosted` `PHP`
 * [Panelbear](https://panelbear.com/) - free real-time website analytics. Supports custom event tracking, email digests, and site speed metrics. `©` `SaaS`
 * [PostHog](https://posthog.com) - Open-source product analytics to track users, events, funnels and trends. Alternative to Mixpanel/Amplitude/Heap. Also includes session recording (alternative to HotJar) and feature flag/experimentation tools (alternative to Optimizely).([Source Code](https://github.com/posthog/posthog)) `MIT` `Python`
+* [stratif.io](https://stratif.io) - Open-source, self-hosted, warehouse-native product analytics. Runs funnels, retention, and path analysis directly on DuckDB, Postgres, Snowflake, or ClickHouse — no ingestion, no SDK. ([Source Code](https://github.com/stratif-io/stratif.io)) `Apache-2.0` `Python/TypeScript`
 * [GrowthBook](https://growthbook.io) - Open-source A/B testing and feature flagging that uses your existing data sources.([Source Code](https://github.com/growthbook/growthbook)) `MIT` `Typescript`
 * [Hotjar](https://www.hotjar.com/) - new and easy way to truly understand your web and mobile site visitors. `©` `SaaS`
 * [Matomo](https://matomo.org/) - Leading open-source analytics platform that gives you more than just powerful analytics, formerly known as Piwik. ([Source Code](https://github.com/matomo-org/)) `GPL-3.0` `PHP`


### PR DESCRIPTION
Adds stratif.io to the General analytics section, alongside PostHog.

stratif.io is an open-source (Apache-2.0), self-hosted, warehouse-native product analytics tool. It runs funnels, retention, and path analysis directly on an existing SQL warehouse (DuckDB, Postgres, Snowflake, ClickHouse, Databricks) — no ingestion pipeline, no tracking SDK.

Alternative to Mixpanel, Amplitude, and PostHog.

- Website: https://stratif.io
- Repo: https://github.com/stratif-io/stratif.io
- Live demo: https://demo.stratif.io