### PR TITLE
Add AuditWidget to SEO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [Snowplow](http://snowplowanalytics.com/) - Analytics tool for web apps with a lot of data. Have every single event, from your websites, mobile apps, desktop applications and server-side systems, stored in your own data warehouse and available to action in real-time. ([Source Code](https://github.com/snowplow/)) `Apache-2.0` `Scala` `real-time`
 
 ## SEO
+* [AuditWidget](https://auditwidget.app/?utm_source=github&utm_medium=awesome_list&utm_campaign=awesome_analytics) - Embeddable SEO audit widget for agency websites. Visitors run a 12-point analysis on any URL and share their email to unlock the full report. `©` `SaaS`
 * [Serposcope](https://serposcope.serphacker.com/) - Serposcope is a free and open-source rank tracker to monitor websites ranking in Google and improve your SEO performances. ([Source Code](https://github.com/serphacker/serposcope)) `MIT` `Java`
 
 ## Privacy focused analytics


### PR DESCRIPTION
Adding [AuditWidget](https://auditwidget.app/) to the SEO section.

**What it does:** AuditWidget is an embeddable SEO audit widget. Drop a single `<script>` tag on a site and visitors can run a 12-point automated SEO analysis (title tags, meta descriptions, HTTPS, mobile-friendliness, page speed, headings, canonicals, image alt text, etc.) directly on the page. The full report unlocks after the visitor shares their email.

**Why this list:** It is a SaaS SEO tool (tagged `©` `SaaS`, matching the existing format used in this list for closed-source SaaS entries). The current SEO section has one entry (Serposcope, focused on rank tracking); AuditWidget covers a different SEO surface — on-page / technical audit — so it is complementary rather than duplicative.

- Live at https://auditwidget.app
- Free plan: 5 audits/month, 1 widget, lead capture included — no credit card required
- Fully functional, not a waitlist

Disclosure: I'm the creator of AuditWidget.