### PR TITLE
Add GoatCounter Dashboard — companion analytics dashboard for GoatCounter

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Often there is no clear differentiation between social media management and anal
 
 * [Freeboard](https://github.com/Freeboard/freeboard) - open source real-time dashboard builder for IOT and other web mashups. `©` `SaaS`
 * [Geckoboard](https://www.geckoboard.com/) - dashboard for key metrics in one place. `©` `SaaS`
+* [GoatCounter Dashboard](https://github.com/abhishekhsingh/goatcounter-dashboard) - Modern analytics dashboard for GoatCounter with interactive charts, choropleth world map, and demo mode. Single HTML file, no build step, no server. ([Demo](https://abhishekhsingh.github.io/goatcounter-dashboard), [Source Code](https://github.com/abhishekhsingh/goatcounter-dashboard)) `MIT` `JavaScript`
 * [Grafana](https://grafana.com/) -  open source dashboard for displaying metrics.([Grafana dashboard inspiration](https://logit.io/blog/post/the-top-21-grafana-dashboards-and-visualisations)) 
 * [Klipfolio](https://www.klipfolio.com/) - Klipfolio is an online dashboard platform for building powerful real-time business dashboards for your team or your clients. `©` `SaaS`
 * [Vizia](https://www.brandwatch.com/products/vizia/) - Visual command center dashboarding solution `©` `SaaS`


### PR DESCRIPTION
Adding GoatCounter Dashboard — an open-source companion dashboard for GoatCounter
(which is already listed in this awesome list under Privacy focused analytics).

- Live demo with sample data: https://abhishekhsingh.github.io/goatcounter-dashboard
  (click "Try Demo" — no API key needed)
- GitHub: https://github.com/abhishekhsingh/goatcounter-dashboard

It's a single HTML file — React + Recharts via CDN, no build step,
no server, no backend. Connects to any GoatCounter instance via the
official API. Features include interactive area charts, choropleth
world map, donut charts, dark/light theme, and flexible date ranges.

MIT licensed.