### PR TITLE
Add NotFair to SEO — open-source Claude Code skills for SEO & paid ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [Snowplow](http://snowplowanalytics.com/) - Analytics tool for web apps with a lot of data. Have every single event, from your websites, mobile apps, desktop applications and server-side systems, stored in your own data warehouse and available to action in real-time. ([Source Code](https://github.com/snowplow/)) `Apache-2.0` `Scala` `real-time`
 
 ## SEO
+* [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code agent skills for SEO, Google Ads, and Meta Ads, connecting to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. Covers site audits, keyword research, meta tags, schema markup, GEO optimization, wasted-spend detection, and creative analysis. ([Source Code](https://github.com/nowork-studio/NotFair)) `MIT`
 * [Serposcope](https://serposcope.serphacker.com/) - Serposcope is a free and open-source rank tracker to monitor websites ranking in Google and improve your SEO performances. ([Source Code](https://github.com/serphacker/serposcope)) `MIT` `Java`
 
 ## Privacy focused analytics


### PR DESCRIPTION
Hi, thanks for maintaining this list — it's a great reference.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** to the SEO section. It's an open-source (MIT) set of Claude Code agent skills for SEO and paid advertising that hooks into live data through four MCP connectors: **Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP**.

Skill areas include site audits, keyword research, meta tag and schema markup generation, GEO optimization, content writing, Google Ads wasted-spend detection, and Meta Ads creative fatigue analysis. It has ~2.9k GitHub stars and is actively maintained.

I placed it at the top of the SEO section but happy to move, reword, or trim the description to better match your style. Let me know!