### PR TITLE
Add FeedPulse — free SEO checkers + embeddable widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [GoatCounter](https://www.goatcounter.com/) - GoatCounter is an open source web analytics platform available as a hosted service (free for non-commercial use) or self-hosted app. ([Source](https://github.com/arp242/goatcounter), [Demo](https://stats.arp242.net/)) `MIT` `SaaS` `Self-Hosted`
 * [Rybbit Analytics](https://rybbit.com/) - Rybbit is powerful, lightweight, and super easy to use analytics. Cookieless and GDPR compliant. Hosted on EU infrastructure in Germany. Self-hosting compatible `©` `SaaS` `self-hosted` `EU`
 * [Clickport](https://clickport.io/) - Privacy-first web analytics without cookies. GDPR compliant, EU-hosted, with session tracking, goals, and real-time dashboard. `©` `SaaS` `EU`
+* [FeedPulse](https://feed-pulse.com) — Free SEO checker + embeddable widget suite for indie sites. 13 SEO tools (DA, DR, SERP, schema, AI audit) + 18 widgets (live traffic, flag counter, weather, GitHub stars). No signup, no paid tier. `©` `SaaS`
 
 ## Heatmap analytics
 


### PR DESCRIPTION
Hi maintainers — proposing FeedPulse for inclusion in this list.

**What it is:** A 100% free SEO checker + embeddable widget suite for indie devs and bootstrapped founders. 13 SEO tools (DA, DR, SERP position, schema markup, meta tag generator, Lighthouse, AI SEO audit + more) and 18 embeddable widgets (live traffic feeds, flag counter, hit counter, weather, countdown, GitHub stars badge, npm downloads badge, Discord members + more).

**Why it fits this list:** 
- ✅ Free forever — no signup, no email gate, no paid tier
- ✅ Public data sources documented at https://feed-pulse.com/data-sources
- ✅ Active project — maintained solo, regular updates
- ✅ Aligns with the list's existing entries on [Plausible and Fathom]

**Live URL:** https://feed-pulse.com

**Compliance with contributing rules:** Entry added alphabetically, matches the existing format of surrounding entries. I've read CONTRIBUTING.md (or the README's contributing section).

Happy to revise the description or move the entry to a different section if a better fit. Thanks for maintaining this list!