### PR TITLE
Add DataHub Pro to Analytics dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Often there is no clear differentiation between social media management and anal
 * [Superset](http://superset.apache.org/) - Modern, enterprise-ready business intelligence web application. ([Source Code](https://github.com/apache/incubator-superset)) `Apache-2.0` `Python`
 * [Socioboard](https://socioboard.org/) - `⚠` Social media management, analytics, and reporting platform supporting nine social media networks out-of-the-box. ([Source Code](https://github.com/socioboard/Socioboard-4.0)) `GPL-3.0` `C#/JavaScript`
 * [EDA](https://eda.jortilles.com/en/jortilles-english/) - EDA is an user friendly Analtical Tool specially designed for busines users.  ([Source Code](https://github.com/jortilles/EDA)) `Apache-2.0` `Angular/Nodejs`
-
+* [DataHub Pro](https://www.datahubpro.co.uk/) - AI analytics for spreadsheets: turn an Excel or CSV file into dashboards, forecasts and reports, with an audit trail for every number. Built for small teams without a data engineer. `SaaS`
 # Other Awesome Lists
 - Other awesome lists [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness).
 - Even more lists [awesome](https://github.com/sindresorhus/awesome).


### PR DESCRIPTION
Adds DataHub Pro to the Analytics dashboards section. It's a spreadsheet-native AI analytics tool that turns Excel/CSV files into dashboards, forecasts and reports, so it sits naturally alongside Metabase, Redash and Superset. Single-line entry, format-consistent. Thanks for maintaining this list!