### PR TITLE
Add GetAppNiche to app store analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The tools listed here are not necessarily mobile analytics tools only. However t
 ## App store analytics
 
 * [Appfigures](http://appfigures.com/) - app store analytics to track sales, reviews and rankings with an API. `©` `SaaS`
+* [GetAppNiche](https://getappniche.com/) - iOS app store intelligence for revenue estimates, ASO keywords, reviews, and competitor research. `©` `SaaS`
 * [Appannie](http://www.appannie.com/) - track your app data from iTunes, Google Play & Amazon. `©` `SaaS`
 * [Distimo](http://www.distimo.com/) - free app store analytics (acquired by [Appannie](http://www.appannie.com/)). `©` `SaaS`
 * [Priori Data](https://prioridata.com/) - track and benchmark the performance of apps on Apple- and Play store. `©` `SaaS`


### PR DESCRIPTION
## Summary
- Add GetAppNiche to the App store analytics section.
- Describe it as an iOS app store intelligence tool for revenue estimates, ASO keywords, reviews, and competitor research.

## Disclosure
I am affiliated with GetAppNiche. I think it fits this list because it provides app store analytics and market intelligence for iOS apps.
