### PR TITLE
Add Open Channel Stats (Social media analytics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Often there is no clear differentiation between social media management and anal
 * [Buffer](https://bufferapp.com/) - Social media publishing and analytics platform. `©` `SaaS`
 * [Topsy](http://topsy.com/) - Social analytics tool with search. `©` `SaaS`
 * [SocialBlade](http://socialblade.com/) - premiere YouTube statistics tracking. `©` `SaaS`
+* [Open Channel Stats](https://openchannelstats.com) - Browse real YouTube channels' full owner analytics — retention, CTR, traffic sources — published by the creators themselves, not estimated; connect your own free to compare. Daily refresh; each public channel exports as a documented SQLite file. `©` `SaaS`
 * [Hootsuite](https://hootsuite.com/) - Social media management dashbaord. `©` `SaaS`
 * [Sproutsocial](http://sproutsocial.com/) - Social media management and analytics platform. `©` `SaaS`
 


### PR DESCRIPTION
Disclosure up front: I'm the maker (solo project).

This adds one line under Social media analytics, next to SocialBlade. Where
SocialBlade estimates from public data, Open Channel Stats shows real owner
analytics — retention, CTR, impressions, traffic sources — because creators
connect their own channel (owner sign-in, two read-only scopes) and choose to
publish it. So you can see how real channels actually grow, and connect yours to
compare. It's free — no paid tier, no ads. Channels are private to the owner by
default; published ones are browsable by anyone with no account, and each public
channel's dataset downloads as a single self-describing SQLite file. Refresh is
daily, not realtime.

Description and tags follow the section's existing format (`©` `SaaS` — it's hosted
and the code isn't open source). Happy to reword or move the line if you'd rather.