### PR TITLE
Add Ciphera Pulse to Privacy focused analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [GoatCounter](https://www.goatcounter.com/) - GoatCounter is an open source web analytics platform available as a hosted service (free for non-commercial use) or self-hosted app. ([Source](https://github.com/arp242/goatcounter), [Demo](https://stats.arp242.net/)) `MIT` `SaaS` `Self-Hosted`
 * [Rybbit Analytics](https://rybbit.com/) - Rybbit is powerful, lightweight, and super easy to use analytics. Cookieless and GDPR compliant. Hosted on EU infrastructure in Germany. Self-hosting compatible `©` `SaaS` `self-hosted` `EU`
 * [Clickport](https://clickport.io/) - Privacy-first web analytics without cookies. GDPR compliant, EU-hosted, with session tracking, goals, and real-time dashboard. `©` `SaaS` `EU`
+* [Ciphera Pulse](https://pulse.ciphera.net/) - Privacy-first, cookieless web analytics; no cookie banner needed, GDPR-native. Built by an EU company (Belgium) with Swiss/EU data hosting. Free tier; AGPL-3.0 frontend, closed backend. ([Source Code](https://github.com/ciphera-net/pulse), [Demo](https://pulse.ciphera.net/demo)) `©` `SaaS` `EU`
 
 ## Heatmap analytics
 


### PR DESCRIPTION
Adds **Ciphera Pulse** to the *Privacy focused analytics* section.

**What it is:** Privacy-first, cookieless web analytics. No cookies means no cookie banner is required, and it is GDPR-native. Built by Ciphera BV, an EU company based in Belgium, with data hosted in Switzerland/EU. Free tier available.

**Why it fits this section:** Same category as its neighbours (Fathom, Plausible, Simple Analytics, Rybbit, Clickport) — a cookieless, GDPR-focused, EU-hosted analytics service.

**Disclosure:** I am affiliated with the project. The description is deliberately honest about scope: the frontend is open source (AGPL-3.0), but the backend is closed, so it is marked `©` and there is no self-hosting option — hence `SaaS` (not `Self-Hosted`).

- Site: https://pulse.ciphera.net/
- Live demo: https://pulse.ciphera.net/demo
- Frontend source (AGPL-3.0): https://github.com/ciphera-net/pulse
- WordPress plugin: https://wordpress.org/plugins/pulse-analytics/

Single-line addition, no other changes.