### PR TITLE
Add rrweb

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [Datafusion](https://datafusion.apache.org) - Arrow centric - SQL and in memory analytics for general usage
 * [Superset-Datafusion](https://github.com/frett27/superset-datafusion) - Superset integration for Datafusion
 * [FullSession](https://www.fullsession.io/) – Session replay and user behavior analytics for websites
+* [rrweb](https://rrweb.com) - Open-source session replay library for the browser. Records the DOM and user interactions and replays them pixel-perfect. ([Source Code](https://github.com/rrweb-io/rrweb)) `MIT` `TypeScript`
 
   
 


### PR DESCRIPTION
Adds rrweb under General analytics.

rrweb is an open-source session replay library: it records the DOM and user interactions in the browser and replays them. The section already lists several session replay tools (Clicktale, LiveSession, Glassbox, FullSession); rrweb is an open-source counterpart, MIT licensed, written in TypeScript.

- Repo: https://github.com/rrweb-io/rrweb (19,899 stars, MIT)
- Docs: https://rrweb.com/docs/

Disclosure: I work on rrweb.
