### PR TITLE
Add Apstal to General analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 
 * [KISSS](https://kis3.dev) - Very minimalistic (KISS) website statistics tool. ([Source Code](https://github.com/kis3/kis3)) `MIT` `Go`
 * [Umami](https://umami.is) - Umami is a simple, fast, privacy-focused alternative to Google Analytics. Umami is GDPR compliant. ([Source Code](https://github.com/umami-software/umami)) `MIT` `JavaScript`
+* [Apstal](https://apstal.com) - AI-powered web analytics with session replay and AI chat. Cookieless, GDPR-compliant.
 
 ## Endpoints
 * [Census](https://getcensus.com/) - The easiest way to sync your customer data from your cloud data warehouse to SaaS applications like Salesforce, Marketo, HubSpot, Zendesk, etc. Census is the operational analytics platform that syncs your data warehouse with all your favorite apps. Get your customer success, sales & marketing teams on the same page by keeping customer data in sync. No engineering favors required—just SQL. `SaaS`

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 
 * [KISSS](https://kis3.dev) - Very minimalistic (KISS) website statistics tool. ([Source Code](https://github.com/kis3/kis3)) `MIT` `Go`
 * [Umami](https://umami.is) - Umami is a simple, fast, privacy-focused alternative to Google Analytics. Umami is GDPR compliant. ([Source Code](https://github.com/umami-software/umami)) `MIT` `JavaScript`
-* [Apstal](https://apstal.com) - AI-powered web analytics with session replay and AI chat. Cookieless, GDPR-compliant.
+* [Apstal](https://apstal.com) - Web analytics with session replay, heatmaps, funnels, and a conversational AI assistant. Cookieless and GDPR-compliant. `©` `SaaS`
 
 ## Endpoints
 * [Census](https://getcensus.com/) - The easiest way to sync your customer data from your cloud data warehouse to SaaS applications like Salesforce, Marketo, HubSpot, Zendesk, etc. Census is the operational analytics platform that syncs your data warehouse with all your favorite apps. Get your customer success, sales & marketing teams on the same page by keeping customer data in sync. No engineering favors required—just SQL. `SaaS`


### PR DESCRIPTION
Adds Apstal (https://apstal.com) to the General analytics section.

Apstal is an AI-first web analytics platform that includes session replay, adblock-resistant server-side tracking, and a conversational AI assistant. It has a free forever tier and a Premium plan at $48/month, fitting the existing mix of SaaS analytics tools in this section.