### PR TITLE
Add Facet to Privacy focused analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [GoatCounter](https://www.goatcounter.com/) - GoatCounter is an open source web analytics platform available as a hosted service (free for non-commercial use) or self-hosted app. ([Source](https://github.com/arp242/goatcounter), [Demo](https://stats.arp242.net/)) `MIT` `SaaS` `Self-Hosted`
 * [Rybbit Analytics](https://rybbit.com/) - Rybbit is powerful, lightweight, and super easy to use analytics. Cookieless and GDPR compliant. Hosted on EU infrastructure in Germany. Self-hosting compatible `©` `SaaS` `self-hosted` `EU`
 * [Clickport](https://clickport.io/) - Privacy-first web analytics without cookies. GDPR compliant, EU-hosted, with session tracking, goals, and real-time dashboard. `©` `SaaS` `EU`
+* [Facet](https://github.com/writerslogic/facet) - Cookieless, privacy-first web analytics & experimentation that runs entirely on the Cloudflare edge (Workers + D1). No cookies, no cross-session identity, raw IP is never stored; GPC/DNT respecting and self-hosted with a one-command deploy. `AGPL-3.0` `Cloudflare Workers`
 
 ## Heatmap analytics
 


### PR DESCRIPTION
Adds **Facet** to the *Privacy focused analytics* section.

Facet is a cookieless, privacy-first web analytics & experimentation tool that runs entirely on the Cloudflare edge (Workers + D1): no cookies, no cross-session identity, raw IP is never stored, GPC/DNT respecting, self-hosted with a one-command deploy. Open source under AGPL-3.0. Sits alongside the existing cookieless self-hosted tools already listed (Umami, Shynet, Swetrix, GoatCounter).

- Repo: https://github.com/writerslogic/facet
- License: AGPL-3.0