### PR TITLE
docs: add AppRankly to Analytics Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Often there is no clear differentiation between social media management and anal
 * [Superset](http://superset.apache.org/) - Modern, enterprise-ready business intelligence web application. ([Source Code](https://github.com/apache/incubator-superset)) `Apache-2.0` `Python`
 * [Socioboard](https://socioboard.org/) - `⚠` Social media management, analytics, and reporting platform supporting nine social media networks out-of-the-box. ([Source Code](https://github.com/socioboard/Socioboard-4.0)) `GPL-3.0` `C#/JavaScript`
 * [EDA](https://eda.jortilles.com/en/jortilles-english/) - EDA is an user friendly Analtical Tool specially designed for busines users.  ([Source Code](https://github.com/jortilles/EDA)) `Apache-2.0` `Angular/Nodejs`
+- [AppRankly](https://github.com/zmsp/AppRankly) - Self-hosted dashboard bringing together iOS App Store Connect and Google Play Console metrics.
 
 # Other Awesome Lists
 - Other awesome lists [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness).


### PR DESCRIPTION
Hey added my repo. 
Adds AppRankly to the **Analytics Dashboards** section.

AppRankly brings mobile app performance metrics (installs, active devices, uninstalls, country distribution) from Google Play & Apple App Store into a unified privacy-focused dashboard.

## Checklist
- [x] Follows repository submission rules
- [x] Alphabetically placed
- [x] Live demo and repo link verified