### PR TITLE
Add Klinky

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [Datafusion](https://datafusion.apache.org) - Arrow centric - SQL and in memory analytics for general usage
 * [Superset-Datafusion](https://github.com/frett27/superset-datafusion) - Superset integration for Datafusion
 * [FullSession](https://www.fullsession.io/) – Session replay and user behavior analytics for websites
+* [Klinky](https://klinky.io) - A/B testing link shortener that splits one link between two destinations, with real-time click analytics. `©` `SaaS`
 
   
 


### PR DESCRIPTION
Adds [Klinky](https://klinky.io) to the General analytics section.

Klinky is an A/B testing link shortener: one short link routes visitors to two destinations at configurable weights, and every click is tracked in real time. It's a lightweight way to run controlled rollout experiments and measure which destination wins, similar in spirit to the A/B testing entries already in this section (GrowthBook, Sitespect). Free tier available.