### PR TITLE
Add smolanalytics to Privacy focused analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [GoatCounter](https://www.goatcounter.com/) - GoatCounter is an open source web analytics platform available as a hosted service (free for non-commercial use) or self-hosted app. ([Source](https://github.com/arp242/goatcounter), [Demo](https://stats.arp242.net/)) `MIT` `SaaS` `Self-Hosted`
 * [Rybbit Analytics](https://rybbit.com/) - Rybbit is powerful, lightweight, and super easy to use analytics. Cookieless and GDPR compliant. Hosted on EU infrastructure in Germany. Self-hosting compatible `©` `SaaS` `self-hosted` `EU`
 * [Clickport](https://clickport.io/) - Privacy-first web analytics without cookies. GDPR compliant, EU-hosted, with session tracking, goals, and real-time dashboard. `©` `SaaS` `EU`
+* [smolanalytics](https://smolanalytics.com/) - Cookieless web and product analytics as a single Go binary with no database: funnels, retention, paths, cohorts, plus AI-visibility, and you can ask it questions from your editor over MCP. ([Source Code](https://github.com/Arjun0606/smolanalytics)) `MIT` `Self-Hosted`/`SaaS`
 
 ## Heatmap analytics
 


### PR DESCRIPTION
Adds [smolanalytics](https://smolanalytics.com/) to **Privacy focused analytics**, alongside Plausible, Umami, Shynet and Swetrix.

Cookieless, MIT-licensed web and product analytics that runs as a single Go binary with no external database. Funnels, retention, paths, cohorts, feature flags, A/B and surveys from the same events, plus AI-visibility (whether the AI assistants name and cite you). It also speaks MCP, so you can ask it questions in plain English from your editor and the answers are computed by deterministic queries over your events rather than generated by a model.

Put it under Privacy focused rather than Developer analytics, since that section is about analytics *on* engineering teams (APM, delivery metrics) whereas this is a privacy-friendly web/product analytics tool on the same shelf as Plausible and Umami.

Format follows the section: name, link, description, Source Code link, license and hosting tags. One line added.