### PR TITLE
Add AI TikTok Analyzer Pro to Social media analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Often there is no clear differentiation between social media management and anal
 * [SocialBlade](http://socialblade.com/) - premiere YouTube statistics tracking. `©` `SaaS`
 * [Hootsuite](https://hootsuite.com/) - Social media management dashbaord. `©` `SaaS`
 * [Sproutsocial](http://sproutsocial.com/) - Social media management and analytics platform. `©` `SaaS`
+* [AI TikTok Analyzer Pro](https://tiktok.poviai.com/) - TikTok content research: rank a creator's public videos by engagement, export comments, AI transcripts and sentiment analysis. `©` `SaaS`
 
 ## Developer analytics
 


### PR DESCRIPTION
Adds one entry to `## Social media analytics`, tagged `©` `SaaS` to match the convention used by the other proprietary entries in that section.

**What it is:** a browser extension and web workbench for researching public TikTok content — ranking a creator's public videos by views, likes or comments; exporting comment threads to Excel/CSV; AI transcription for videos with no captions; and comment sentiment/theme analysis across 9 languages.

**Why here:** the section covers cross-network social analytics (Brandwatch, Quintly, Sprout Social) and single-network trackers (SocialBlade for YouTube). TikTok isn't currently represented, and TikTok's own interface exports neither comments nor transcripts, so this fills a real gap rather than duplicating an existing entry.

**Scope note:** it analyzes public content and does not provide GMV or sales data — for that, the commerce platforms are the right tool. Flagging it so the description doesn't oversell.

**Disclosure:** I work on this tool. Free quota plus paid tiers, hence the `©` `SaaS` markers. Happy to shorten the description or move it if you'd prefer.