### PR TITLE
Add DAC to Analytics dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Often there is no clear differentiation between social media management and anal
 * [Superset](http://superset.apache.org/) - Modern, enterprise-ready business intelligence web application. ([Source Code](https://github.com/apache/incubator-superset)) `Apache-2.0` `Python`
 * [Socioboard](https://socioboard.org/) - `⚠` Social media management, analytics, and reporting platform supporting nine social media networks out-of-the-box. ([Source Code](https://github.com/socioboard/Socioboard-4.0)) `GPL-3.0` `C#/JavaScript`
 * [EDA](https://eda.jortilles.com/en/jortilles-english/) - EDA is an user friendly Analtical Tool specially designed for busines users.  ([Source Code](https://github.com/jortilles/EDA)) `Apache-2.0` `Angular/Nodejs`
+* [DAC](https://getbruin.com/docs/dac/) - dashboard-as-code tool that defines dashboards in YAML and TSX, with a built-in semantic layer for metrics and dimensions. ([Source Code](https://github.com/bruin-data/dac)) `AGPL-3.0` `Go` `Self-Hosted`
 
 # Other Awesome Lists
 - Other awesome lists [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness).


### PR DESCRIPTION
Adds [DAC](https://github.com/bruin-data/dac) to the **Analytics dashboards** section.

DAC is an open-source dashboard-as-code tool. Dashboards are defined in YAML or TSX files, version-controlled like any other code, and served from a single Go binary. It has a built-in semantic layer for defining metrics and dimensions once and reusing them across widgets, and connects to Postgres, MySQL, Snowflake, BigQuery, Redshift and Databricks. AGPL-3.0, ~700 stars, actively developed.

- Not currently listed; no open PR covers it.
- Appended to the end of the section, following the insertion order used there.
- Format matches the surrounding entries, including the `([Source Code](...))` link and the `AGPL-3.0` `Go` `Self-Hosted` tags.

Disclosure: I work on the team that builds DAC.